### PR TITLE
DB maintenance

### DIFF
--- a/eventstore/eventstore.go
+++ b/eventstore/eventstore.go
@@ -24,8 +24,10 @@ type SnapshotQuery struct {
 type EventStore interface {
 	Save(ctx context.Context, groupId string, aggregateId string, events []event.Event) (concurrencyException bool, err error)
 	SaveSnapshot(ctx context.Context, groupId string, aggregateId string, event event.Event) (concurrencyException bool, err error)
+	LoadUpToVersion(ctx context.Context, queries []VersionQuery, eventHandler event.Handler) error
 	LoadFromVersion(ctx context.Context, queries []VersionQuery, eventHandler event.Handler) error
 	LoadFromSnapshot(ctx context.Context, queries []SnapshotQuery, eventHandler event.Handler) error
+	RemoveUpToVersion(ctx context.Context, queries []VersionQuery) error
 }
 
 // GoroutinePoolGoFunc processes actions via provided function

--- a/eventstore/maintenance/maintenance.go
+++ b/eventstore/maintenance/maintenance.go
@@ -4,17 +4,20 @@ import (
 	"context"
 )
 
-type MaintenanceEventStore interface {
+// EventStore provides interface over the maintenance functionality for an event store
+type EventStore interface {
 	Insert(ctx context.Context, task Task) error
 	Query(ctx context.Context, limit int, taskHandler TaskHandler) error
 	Remove(ctx context.Context, task Task) error
 }
 
+// Task used to target a specific db record
 type Task struct {
 	AggregateID string
 	Version     uint64
 }
 
+// TaskHandler handles the maintenance db queries
 type TaskHandler interface {
 	Handle(ctx context.Context, iter Iter) (err error)
 }

--- a/eventstore/maintenance/maintenance.go
+++ b/eventstore/maintenance/maintenance.go
@@ -1,0 +1,23 @@
+package maintenance
+
+import (
+	"context"
+
+	"github.com/go-ocf/cqrs/eventstore"
+)
+
+type MaintenanceEventStore interface {
+	Insert(ctx context.Context, task eventstore.VersionQuery) error
+	Query(ctx context.Context, limit int, taskHandler TaskHandler) error
+	Remove(ctx context.Context, task eventstore.VersionQuery) error
+}
+
+type TaskHandler interface {
+	Handle(ctx context.Context, iter Iter) (err error)
+}
+
+//Iter provides iterator over maintenance db records
+type Iter interface {
+	Next(ctx context.Context, task *eventstore.VersionQuery) bool
+	Err() error
+}

--- a/eventstore/maintenance/maintenance.go
+++ b/eventstore/maintenance/maintenance.go
@@ -2,14 +2,17 @@ package maintenance
 
 import (
 	"context"
-
-	"github.com/go-ocf/cqrs/eventstore"
 )
 
 type MaintenanceEventStore interface {
-	Insert(ctx context.Context, task eventstore.VersionQuery) error
+	Insert(ctx context.Context, task Task) error
 	Query(ctx context.Context, limit int, taskHandler TaskHandler) error
-	Remove(ctx context.Context, task eventstore.VersionQuery) error
+	Remove(ctx context.Context, task Task) error
+}
+
+type Task struct {
+	AggregateID string
+	Version     uint64
 }
 
 type TaskHandler interface {
@@ -18,6 +21,6 @@ type TaskHandler interface {
 
 //Iter provides iterator over maintenance db records
 type Iter interface {
-	Next(ctx context.Context, task *eventstore.VersionQuery) bool
+	Next(ctx context.Context, task *Task) bool
 	Err() error
 }

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -537,7 +537,7 @@ func (s *EventStore) Close(ctx context.Context) error {
 }
 
 // newDBEvent returns a new dbEvent for an event.
-func makeDBEvent(groupId, aggregateId string, event event.Event, marshaler event.MarshalerFunc) (bson.M, error) {
+func makeDBEvent(groupID, aggregateID string, event event.Event, marshaler event.MarshalerFunc) (bson.M, error) {
 	// Marshal event data if there is any.
 	raw, err := marshaler(event)
 	if err != nil {
@@ -545,37 +545,37 @@ func makeDBEvent(groupId, aggregateId string, event event.Event, marshaler event
 	}
 
 	return bson.M{
-		aggregateIdKey: aggregateId,
-		groupIdKey:     groupId,
+		aggregateIdKey: aggregateID,
+		groupIdKey:     groupID,
 		versionKey:     event.Version(),
 		dataKey:        raw,
 		eventTypeKey:   event.EventType(),
-		idKey:          groupId + "." + aggregateId + "." + strconv.FormatUint(event.Version(), 10),
+		idKey:          groupID + "." + aggregateID + "." + strconv.FormatUint(event.Version(), 10),
 	}, nil
 }
 
 // newDBEvent returns a new dbEvent for an event.
-func makeDBSnapshot(groupId, aggregateId string, version uint64) bson.M {
+func makeDBSnapshot(groupID, aggregateID string, version uint64) bson.M {
 	return bson.M{
-		idKey:          groupId + "." + aggregateId,
-		groupIdKey:     groupId,
-		aggregateIdKey: aggregateId,
+		idKey:          groupID + "." + aggregateID,
+		groupIdKey:     groupID,
+		aggregateIdKey: aggregateID,
 		versionKey:     version,
 	}
 }
 
-func (s *EventStore) SaveSnapshotQuery(ctx context.Context, groupId, aggregateId string, version uint64) (concurrencyException bool, err error) {
+func (s *EventStore) SaveSnapshotQuery(ctx context.Context, groupId, aggregateID string, version uint64) (concurrencyException bool, err error) {
 	s.LogDebugfFunc("mongodb.Evenstore.SaveSnapshotQuery start")
 	t := time.Now()
 	defer func() {
 		s.LogDebugfFunc("mongodb.Evenstore.SaveSnapshotQuery takes %v", time.Since(t))
 	}()
 
-	if aggregateId == "" {
-		return false, fmt.Errorf("cannot save snapshot query: invalid query.AggregateId")
+	if aggregateID == "" {
+		return false, fmt.Errorf("cannot save snapshot query: invalid query.aggregateID")
 	}
 
-	sbSnap := makeDBSnapshot(groupId, aggregateId, version)
+	sbSnap := makeDBSnapshot(groupId, aggregateID, version)
 	col := s.client.Database(s.DBName()).Collection(snapshotCName)
 	/*
 		err = ensureIndex(ctx, col, snapshotsQueryIndex, snapshotsQueryGroupIdIndex)
@@ -684,6 +684,7 @@ func (s *EventStore) LoadSnapshotQueries(ctx context.Context, queries []eventsto
 	return err
 }
 
+// RemoveUpToVersion deletes the aggragates events up to a specific version.
 func (s *EventStore) RemoveUpToVersion(ctx context.Context, queries []eventstore.VersionQuery) error {
 	deleteMgoQuery, err := versionQueriesToMgoQuery(queries, signOperator_lt)
 	if err != nil {

--- a/eventstore/mongodb/eventstore.go
+++ b/eventstore/mongodb/eventstore.go
@@ -564,7 +564,8 @@ func makeDBSnapshot(groupID, aggregateID string, version uint64) bson.M {
 	}
 }
 
-func (s *EventStore) SaveSnapshotQuery(ctx context.Context, groupId, aggregateID string, version uint64) (concurrencyException bool, err error) {
+// SaveSnapshotQuery upserts the snapshot record
+func (s *EventStore) SaveSnapshotQuery(ctx context.Context, groupID, aggregateID string, version uint64) (concurrencyException bool, err error) {
 	s.LogDebugfFunc("mongodb.Evenstore.SaveSnapshotQuery start")
 	t := time.Now()
 	defer func() {
@@ -575,7 +576,7 @@ func (s *EventStore) SaveSnapshotQuery(ctx context.Context, groupId, aggregateID
 		return false, fmt.Errorf("cannot save snapshot query: invalid query.aggregateID")
 	}
 
-	sbSnap := makeDBSnapshot(groupId, aggregateID, version)
+	sbSnap := makeDBSnapshot(groupID, aggregateID, version)
 	col := s.client.Database(s.DBName()).Collection(snapshotCName)
 	/*
 		err = ensureIndex(ctx, col, snapshotsQueryIndex, snapshotsQueryGroupIdIndex)

--- a/eventstore/mongodb/maintenance.go
+++ b/eventstore/mongodb/maintenance.go
@@ -1,0 +1,139 @@
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
+
+	"github.com/go-ocf/cqrs/eventstore"
+	"github.com/go-ocf/cqrs/eventstore/maintenance"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+const aggregateVersionsCName = "aggregateversions"
+
+// dbEvent is the internal record for the MongoDB event store used to save and load
+// the latest versions per aggregate (snapshot follows right after this version) from the DB.
+type dbAggregateVersion struct {
+	AggregateID string `bson:"aggregateIdKey"`
+	ID          string `bson:"_id"`
+	Version     uint64 `bson:"versionKey"`
+}
+
+func makeDbAggregateVersion(aggregateID string, version uint64) (dbAggregateVersion, error) {
+	return dbAggregateVersion{
+		AggregateID: aggregateID,
+		Version:     version,
+		ID:          aggregateID + "." + strconv.FormatUint(version, 10),
+	}, nil
+}
+
+func (s *EventStore) Insert(ctx context.Context, task eventstore.VersionQuery) error {
+	record, err := makeDbAggregateVersion(task.AggregateId, task.Version)
+	if err != nil {
+		return err
+	}
+
+	col := s.client.Database(s.DBName()).Collection(aggregateVersionsCName)
+
+	opts := options.UpdateOptions{}
+	opts.SetUpsert(true)
+
+	res, err := col.UpdateOne(ctx,
+		bson.M{
+			"_id": record.ID,
+			versionKey: bson.M{
+				"$lt": record.Version,
+			},
+		},
+		bson.M{
+			"$set": record,
+		},
+		&opts,
+	)
+	if err != nil {
+		if err == mongo.ErrNilDocument || IsDup(err) {
+			// someone has already updated the store with a newer version
+			return nil
+		}
+		return fmt.Errorf("db maintenance - could not upsert record with aggregate ID %v, version %d - %v", task.AggregateId, task.Version, err)
+	}
+	if res.UpsertedCount != 1 {
+		return fmt.Errorf("db maintenance - could not upsert record with aggregate ID %v, version %d", task.AggregateId, task.Version)
+	}
+	return nil
+}
+
+type dbAggregateVersionIterator struct {
+	iter *mongo.Cursor
+}
+
+func (i *dbAggregateVersionIterator) Next(ctx context.Context, task *eventstore.VersionQuery) bool {
+	var dbRecord dbAggregateVersion
+
+	if !i.iter.Next(ctx) {
+		return false
+	}
+
+	err := i.iter.Decode(&dbRecord)
+	if err != nil {
+		return false
+	}
+
+	task.AggregateId = dbRecord.AggregateID
+	task.Version = dbRecord.Version
+	return true
+}
+
+func (i *dbAggregateVersionIterator) Err() error {
+	return i.iter.Err()
+}
+
+func (s *EventStore) Query(ctx context.Context, limit int, taskHandler maintenance.TaskHandler) error {
+	// TODO Not looking for a particular aggregate id + version!
+	mgoQuery := versionQueryToMgoQuery(eventstore.VersionQuery{}, signOperator_gte)
+
+	// TODO create indexu ?
+	// opts := options.FindOptions{}
+	// opts.SetHint(eventsQueryAggregateIdIndex)
+	iter, err := s.client.Database(s.DBName()).Collection(aggregateVersionsCName).Find(ctx, mgoQuery)
+	if err == mongo.ErrNilDocument {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// i := dbAggregateVersionIterator{
+	// 	iter: iter,
+	// }
+	//	err = eh.Handle(ctx, &i)
+
+	errClose := iter.Close(ctx)
+	if err == nil {
+		return errClose
+	}
+	return err
+}
+
+func (s *EventStore) Remove(ctx context.Context, task eventstore.VersionQuery) error {
+	record, err := makeDbAggregateVersion(task.AggregateId, task.Version)
+	if err != nil {
+		return err
+	}
+
+	col := s.client.Database(s.DBName()).Collection(aggregateVersionsCName)
+
+	res, err := col.DeleteOne(ctx, record)
+	if err != nil {
+		return err
+	}
+	if res.DeletedCount != 1 {
+		return fmt.Errorf("db maintenance - could not remove record with given aggregate ID %s and/or version %d", task.AggregateId, task.Version)
+	}
+
+	return nil
+}

--- a/eventstore/mongodb/maintenance_test.go
+++ b/eventstore/mongodb/maintenance_test.go
@@ -1,0 +1,138 @@
+package mongodb
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/go-ocf/cqrs/eventstore/maintenance"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/bson"
+)
+
+type mockRecordHandler struct {
+	lock  sync.Mutex
+	tasks map[string]maintenance.Task
+}
+
+func newMockRecordHandler() *mockRecordHandler {
+	return &mockRecordHandler{tasks: make(map[string]maintenance.Task)}
+}
+
+func (eh *mockRecordHandler) SetElement(aggregateID string, task maintenance.Task) {
+	var aggregate maintenance.Task
+	var ok bool
+
+	eh.lock.Lock()
+	defer eh.lock.Unlock()
+	if aggregate, ok = eh.tasks[aggregateID]; !ok {
+		eh.tasks[aggregateID] = maintenance.Task{AggregateID: task.AggregateID, Version: task.Version}
+	}
+	aggregate.AggregateID = task.AggregateID
+	aggregate.Version = task.Version
+}
+
+func (eh *mockRecordHandler) Handle(ctx context.Context, iter maintenance.Iter) error {
+	var task maintenance.Task
+
+	for iter.Next(ctx, &task) {
+		eh.SetElement(task.AggregateID, task)
+	}
+	return nil
+}
+
+func TestMaintenance(t *testing.T) {
+	// Local Mongo testing with Docker
+	host := os.Getenv("MONGO_HOST")
+
+	if host == "" {
+		// Default to localhost
+		host = "localhost:27017"
+	}
+	ctx := context.Background()
+
+	store, err := NewEventStore(
+		ctx,
+		host,
+		"test_mongodb",
+		"maintenance", 1,
+		func(f func()) error { go f(); return nil },
+		bson.Marshal,
+		bson.Unmarshal,
+		nil)
+	require.NoError(t, err)
+	require.NotNil(t, store)
+
+	defer store.Close(ctx)
+	defer func() {
+		t.Log("clearing db")
+		err := store.Clear(ctx)
+		require.NoError(t, err)
+	}()
+
+	aggregateID1 := "aggregateID1"
+	tasksToSave := []maintenance.Task{
+		maintenance.Task{
+			AggregateID: aggregateID1,
+		},
+		maintenance.Task{
+			AggregateID: aggregateID1,
+			Version:     1,
+		},
+		maintenance.Task{
+			AggregateID: aggregateID1,
+			Version:     2,
+		},
+		maintenance.Task{
+			AggregateID: aggregateID1,
+			Version:     3,
+		},
+		maintenance.Task{
+			AggregateID: aggregateID1,
+			Version:     4,
+		},
+	}
+
+	t.Log("insert maintenance record without body")
+	err = store.Insert(ctx, maintenance.Task{})
+	require.Error(t, err)
+
+	t.Log("insert maintenance record")
+	err = store.Insert(ctx, tasksToSave[1])
+	require.NoError(t, err)
+
+	t.Log("insert maintenance record with higher version")
+	err = store.Insert(ctx, tasksToSave[4])
+	require.NoError(t, err)
+
+	t.Log("query maintenance records")
+	eh1 := newMockRecordHandler()
+	err = store.Query(ctx, 777, eh1)
+	require.NoError(t, err)
+	require.Equal(t, tasksToSave[4], eh1.tasks[aggregateID1])
+
+	t.Log("insert maintenance record with lower version")
+	err = store.Insert(ctx, tasksToSave[3])
+	require.Error(t, err)
+
+	t.Log("query maintenance records")
+	eh2 := newMockRecordHandler()
+	err = store.Query(ctx, 777, eh2)
+	require.NoError(t, err)
+	require.Equal(t, tasksToSave[4], eh2.tasks[aggregateID1])
+
+	t.Log("remove maintenance record - incorrect version")
+	err = store.Remove(ctx, tasksToSave[3])
+	require.Error(t, err)
+
+	t.Log("remove maintenance record")
+	err = store.Remove(ctx, tasksToSave[4])
+	require.NoError(t, err)
+
+	t.Log("query maintenance records - empty collection")
+	eh3 := newMockRecordHandler()
+	err = store.Query(ctx, 777, eh3)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(eh3.tasks))
+}


### PR DESCRIPTION
Add `LoadUpToVersion()` and `RemoveUpToVersion()` functions to `EventStore` that load/deletes records from the DB with open interval.
Add new DB table which stores the latest version (before snapshot) per aggregate - functions `Insert()`, `Query()` and `Remove()`.